### PR TITLE
Fix: Allow nokogiri versions > 1.10.5.

### DIFF
--- a/gauntlt.gemspec
+++ b/gauntlt.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'cucumber', '= 1.3.20'
   s.add_runtime_dependency 'aruba', '= 0.7.4'
   s.add_runtime_dependency 'ffi', '~> 1.9.24'
-  s.add_runtime_dependency 'nokogiri', '~> 1.10.5'
+  s.add_runtime_dependency 'nokogiri', '>= 1.10.5'
   s.add_runtime_dependency 'optimist', '~> 3.0.0'
 
 end


### PR DESCRIPTION
### Description

Version lock on nokogiri was messing with my vibe.

### Fix

I did a bad thing, and permit all versions after 1.10.5. This will allow security conscious people to upgrade nokogiri to 1.11.0